### PR TITLE
Changed High Jump and Long Jump subtitles

### DIFF
--- a/js/data_movement.js
+++ b/js/data_movement.js
@@ -68,7 +68,7 @@ data_movement = [
     {
         title: "High jump",
         icon: "wingfoot",
-        subtitle: "Cost: 5ft per 5ft",
+        subtitle: "Height: 3 + STR MOD*",
         description: "Movement cost: 5ft per 5ft jumped",
         
         reference: "PHB, pg. 182.",
@@ -82,7 +82,7 @@ data_movement = [
     {
         title: "Long jump",
         icon: "wingfoot",
-        subtitle: "Cost: 5ft per 5ft",
+        subtitle: "Distance: STR ability score*",
         description: "Movement cost: 5ft per 5ft jumped",
         reference: "PHB, pg. 182.",
         bullets: [


### PR DESCRIPTION
Changed the jumping subtitles to more useful quick reference.  Asterisks to indicate there's a caveat (moving at least 10 ft immediately before)